### PR TITLE
Implemented revert complete

### DIFF
--- a/source/bullet-point.js
+++ b/source/bullet-point.js
@@ -1,6 +1,6 @@
 // Bullet point/entry custom component
 
-import { complete_migration, high_low_migration, updateView, populate_global_arrays, delete_bullet_db } from './script.js';
+import { complete_migration, high_low_migration, updateView, populate_global_arrays, delete_bullet_db, revert_complete_migration } from './script.js';
 
 class BulletPoint extends HTMLElement {
     constructor() {
@@ -72,9 +72,9 @@ class BulletPoint extends HTMLElement {
             high_low_migration(entry.task_field, entry.bullet_id);
         });
 
-        //revert from complete to HP or LP
+        //revert from complete to LP (Reverts to LP even if bullet was in HP previously)
         buttons[2].addEventListener('click', function() {
-            console.log("reverting");
+            revert_complete_migration(entry.task_field, entry.bullet_id);
         });
 
         //delete

--- a/source/script.js
+++ b/source/script.js
@@ -120,7 +120,7 @@ function high_low_migration(task_field, id) {
     }
 }
 
-export { complete_migration, high_low_migration, updateView, populate_global_arrays, delete_bullet_db };
+export { complete_migration, high_low_migration, updateView, populate_global_arrays, delete_bullet_db, revert_complete_migration };
 
 function complete_migration(task_field, id) {
     if (task_field != 'HP' && task_field != 'LP'){
@@ -145,6 +145,33 @@ function complete_migration(task_field, id) {
         throw "Cannot find bullet id in task_field";
     }
 }
+
+function revert_complete_migration(task_field, id){
+    if(task_field != 'C'){
+        throw 'Wrong task_field: Should be \'C\'! ';
+    }
+    else{
+        let completed_list = JSON.parse(localStorage.getItem('C'));
+        let low_priority_list = JSON.parse(localStorage.getItem('LP'));
+        let temp_bullet;
+        for(let bullet of completed_list[0]){
+            if(bullet.bullet_id == id){
+                temp_bullet = bullet;
+                delete_bullet_db(temp_bullet.task_field, temp_bullet.bullet_id);
+                temp_bullet.task_field = 'LP';
+                low_priority_list[0].unshift(temp_bullet); //By default moved to LP column, even if bullet was previously in HP column
+                localStorage.setItem('LP', JSON.stringify(low_priority_list));
+                populate_global_arrays();
+                updateView(task_field);
+                updateView("LP");
+                return;
+            }
+        }
+        throw "Cannot find bullet id in task_field";
+    }
+}
+
+
 /* press enter to submit the text post rather than pressing the button
 let textBox = document.getElementById('editor_text');
 


### PR DESCRIPTION
Implemented the `Revert Complete` button functionality.

Before button press: 
![before](https://user-images.githubusercontent.com/54558160/119269711-ef181000-bbad-11eb-8159-374e90e42795.PNG)


After button press:
![after](https://user-images.githubusercontent.com/54558160/119269730-02c37680-bbae-11eb-97e8-cf50bc71ef74.PNG)


_Note_: It was decided in the 5/22 back-end meeting that bullets moved with revert complete would be moved to the LP column by default, even if they were originally in the HP column. 
