### PR TITLE
added completed timestamps

### DIFF
--- a/source/bullet-point.js
+++ b/source/bullet-point.js
@@ -22,6 +22,7 @@ class BulletPoint extends HTMLElement {
             <span class="date"></span>
             <span class="entry_label"></span>
             <span class="bullet_id"></span>
+            <!-- <br> <span class="comp_time"></span> print timestamp -->
             <button class="not-complete">Mark Complete</button>
             <button class="not-complete">Change Priority</button>
             <button class="complete">Revert Complete</button>
@@ -51,6 +52,7 @@ class BulletPoint extends HTMLElement {
         spans[0].append(entry.deadline);
         spans[1].append(entry.labels);
         spans[2].append(entry.bullet_id);
+        //spans[3].append(entry.comp_time); // uncomment to print timestamp
 
         let buttons = article.querySelectorAll('button');
 

--- a/source/script.js
+++ b/source/script.js
@@ -89,10 +89,12 @@ function high_low_migration(task_field, id) {
             let other_list = JSON.parse(localStorage.getItem('LP'));
             let temp_bullet;
             for(let bullet of origin_list[0]){
-                if(bullet.bullet_id == id) {
+                if(bullet.bullet_id == id) { //find bullet in array
                     temp_bullet = bullet;
+                    //find and remove from array HP
                     delete_bullet_db(temp_bullet.task_field, temp_bullet.bullet_id);
                     temp_bullet.task_field = 'LP';
+                    //add to array LP
                     other_list[0].unshift(temp_bullet);
                     localStorage.setItem('LP', JSON.stringify(other_list));
                     populate_global_arrays();
@@ -107,10 +109,12 @@ function high_low_migration(task_field, id) {
             let other_list = JSON.parse(localStorage.getItem('HP'));
             let temp_bullet;
             for(let bullet of origin_list[0]){
-                if(bullet.bullet_id == id) {
+                if(bullet.bullet_id == id) { //find bullet in array
                     temp_bullet = bullet;
+                    //find and remove from array LP
                     delete_bullet_db(temp_bullet.task_field, temp_bullet.bullet_id);
                     temp_bullet.task_field = 'HP';
+                    //add to array HP
                     other_list[0].unshift(temp_bullet);
                     localStorage.setItem('HP', JSON.stringify(other_list));
                     populate_global_arrays();
@@ -135,11 +139,14 @@ function complete_migration(task_field, id) {
         let completed_list = JSON.parse(localStorage.getItem('C'));
         let temp_bullet;
         for(let bullet of origin_list[0]){
-            if(bullet.bullet_id == id) {
+            if(bullet.bullet_id == id) { //find bullet in array
                 temp_bullet = bullet;
+                //find and remove from LP or HP
                 delete_bullet_db(temp_bullet.task_field, temp_bullet.bullet_id);
                 temp_bullet.task_field = 'C';
-                completed_list[0].unshift(temp_bullet); //insert removed bullet to 'C'
+                const now = new Date();
+                temp_bullet.comp_time = now.toISOString(); //set timestamp
+                completed_list[0].unshift(temp_bullet); //insert new bullet to 'C'
                 localStorage.setItem('C', JSON.stringify(completed_list));
                 populate_global_arrays();
                 update_view(task_field);
@@ -165,6 +172,7 @@ function revert_complete_migration(task_field, id){
                 temp_bullet = bullet;
                 delete_bullet_db(temp_bullet.task_field, temp_bullet.bullet_id);
                 temp_bullet.task_field = 'LP';
+                temp_bullet.comp_time = null; //remove "comp_time"
                 low_priority_list[0].unshift(temp_bullet); //By default moved to LP column, even if bullet was previously in HP column
                 localStorage.setItem('LP', JSON.stringify(low_priority_list));
                 populate_global_arrays();
@@ -200,7 +208,7 @@ function create_bullet(e) {
     let deadline = document.getElementById('entry_date').value;
     let content = document.getElementById('editor_text').textContent;
     let bullet_id = get_bullet_id();
-    document.getElementById('editor_text').textContent = ""; //clear text box, temp fix?
+    document.getElementById('editor_text').textContent = ""; //clear text box
 
     /* TODO: will have to change how we handle labels later; will probably have to loop
     across all label checkboxes and add the ones that have been selected to labels */
@@ -218,7 +226,7 @@ function create_bullet(e) {
         "deadline": deadline,
         "content": content,
         "bullet_id": bullet_id,
-        "CompTimeStamp": null
+        "comp_time": null
     };
 
     create_bullet_db(bullet); // CUD


### PR DESCRIPTION
when a bullet is marked as complete, add timestamp
when a bullet is unmarked, timestamp is set back to null

The timestamps are part of the entry/bullet JSobject and are stored as an ISO formatted string ex. `2021-05-24T19:58:25.330Z`.
This is so that the string can be passed back into the Date constructor to create a date object, for easy comparisons when implementing the auto move to archive.

This pull request closes #39 