### PR TITLE
Show buttons on hover

### DIFF
--- a/source/bullet-point.js
+++ b/source/bullet-point.js
@@ -15,6 +15,14 @@ class BulletPoint extends HTMLElement {
             .entry {
                 border: 2px solid black;
                 border-radius: 5px;
+                padding: 5px;
+            }
+            .hide-hover {
+                display: none;
+                cursor: pointer;
+            }
+            .entry:hover > .hide-hover {
+                display: inline;
             }
         </style>
         <article class="entry">
@@ -24,6 +32,8 @@ class BulletPoint extends HTMLElement {
             <span class="bullet_id"></span>
             <span class="bullet_task_field"></span>
             <!-- <br> <span class="comp_time"></span> print timestamp -->
+            <br>
+            <!-- buttons go here-->
         </article>
         `;
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/72235530/119579989-70210400-bd74-11eb-8f99-08b5f2d87bf1.png)

After:
![image](https://user-images.githubusercontent.com/72235530/119580019-8038e380-bd74-11eb-8de3-7d9ca269cda8.png)
Screengrab deleted my mouse cursor, these should be one in the second pic.

I had to alter how we created buttons. We used to make all the buttons and just hide the ones that were not needed, now we only create the buttons that are needed.

closes #35 