### PR TITLE
Reset choices after creating bullet

### DIFF
--- a/source/script.js
+++ b/source/script.js
@@ -353,7 +353,6 @@ function reset_bullet_choices(){
     document.getElementById("check_priority").checked = false;
     document.getElementById("select2").selectedIndex = 0;
     document.getElementById("entry_date").value = '';
-
 }
 
 //Helper method for editing contents of existing bullet


### PR DESCRIPTION
This PR should close issue #40. 

Before creating bullet: 
![Capture](https://user-images.githubusercontent.com/54558160/119770454-12bead00-be71-11eb-810a-7ea45832955b.PNG)

After creating bullet:
![after](https://user-images.githubusercontent.com/54558160/119770489-1a7e5180-be71-11eb-8d69-a7c15f8c3674.PNG)

