### PR TITLE
Fixed url in back arrow test (quick fix)

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -218,6 +218,6 @@ describe('Basic user flow for SPA ', () => {
 
   test('Back arrow button', async() => {
       await page.goBack();
-      expect(page.url()).toBe("https://nbuhr9.github.io/test-server/");
+      expect(page.url()).toBe("https://nbuhr9.github.io/test-server/#");
   });
 });


### PR DESCRIPTION
Back arrow test previously failed because the URL was slightly different. This is because when we perform a check for which color theme to use upon loading up the site, a # gets appended to the end of the URL. Then clicking the browser's go-back button after checking out the Archive (as opposed to the go-back button in the window itself) doesn't get rid of this symbol. So I updated the URL in the tests so they would make the correct comparisons again.